### PR TITLE
docs: clarification of creation migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ $ gem install fast_count
 
 If you are using PostgreSQL, you need to create a database function, used internally:
 
+```sh
+$ rails generate migration install_fast_count
+```
+
+with the content:
+
 ```ruby
 class InstallFastCount < ActiveRecord::Migration[7.0]
   def up


### PR DESCRIPTION
I have a problem with the migration because I created with

`rails generate migration fast_count`

and the migration fail when execute

`rails db:migrate`

I think is best to explicit this step