### PR TITLE
Allow fast count on primary key

### DIFF
--- a/lib/fast_count/adapters/mysql_adapter.rb
+++ b/lib/fast_count/adapters/mysql_adapter.rb
@@ -38,6 +38,8 @@ module FastCount
 
       private
         def index_exists?(table_name, column_name)
+          return true if @connection.schema_cache.primary_keys(table_name) == column_name.to_s
+
           indexes = @connection.schema_cache.indexes(table_name)
           indexes.find do |index|
             index.using == :btree && Array(index.columns).first == column_name.to_s

--- a/lib/fast_count/adapters/postgresql_adapter.rb
+++ b/lib/fast_count/adapters/postgresql_adapter.rb
@@ -104,6 +104,8 @@ module FastCount
 
       private
         def index_exists?(table_name, column_name)
+          return true if @connection.schema_cache.primary_keys(table_name) == column_name.to_s
+
           indexes = @connection.schema_cache.indexes(table_name)
           indexes.find do |index|
             index.using == :btree &&


### PR DESCRIPTION
Primary key is not returned in `#indexes`, at least on Postgres.